### PR TITLE
feat/metrics: add metrics collector from /metrics/metrics

### DIFF
--- a/pkg/rundeck/client.go
+++ b/pkg/rundeck/client.go
@@ -13,14 +13,15 @@ import (
 
 // ClientConfig represents a client configuration
 type ClientConfig struct {
-	BaseURL    string
-	Token      string
-	VerifySSL  bool
-	Username   string
-	Password   string
-	AuthMethod string
-	APIVersion string
-	HTTPClient *http.Client
+	BaseURL      string
+	Token        string
+	VerifySSL    bool
+	Username     string
+	Password     string
+	AuthMethod   string
+	APIVersion   string
+	HTTPClient   *http.Client
+	OverridePath bool
 }
 
 // Client represents a rundeck client
@@ -35,9 +36,10 @@ func defaultClientConfig() (*ClientConfig, error) {
 		return nil, err
 	}
 	return &ClientConfig{
-		VerifySSL:  true,
-		APIVersion: MaxRundeckVersion,
-		HTTPClient: c,
+		VerifySSL:    true,
+		APIVersion:   MaxRundeckVersion,
+		HTTPClient:   c,
+		OverridePath: false,
 	}, nil
 }
 

--- a/pkg/rundeck/http.go
+++ b/pkg/rundeck/http.go
@@ -45,7 +45,12 @@ func requestExpects(code int) httpclient.RequestOption {
 }
 
 func (rc *Client) makeAPIPath(path string) string {
-	return rc.Config.BaseURL + "/api/" + rc.Config.APIVersion + "/" + path
+	if rc.Config.OverridePath {
+		return rc.Config.BaseURL + path
+	} else {
+		return rc.Config.BaseURL + "/api/" + rc.Config.APIVersion + "/" + path
+	}
+
 }
 
 // This is our custom redirect policy for tracking if we get redirected to to the error pages

--- a/pkg/rundeck/system_metrics.go
+++ b/pkg/rundeck/system_metrics.go
@@ -26,7 +26,6 @@ func (c *Client) GetMetrics() (*SystemMetrics, error) {
 		return nil, err
 	}
 	ls := SystemMetrics{}
-	// data, err := c.metricsHttpGet("/metrics/metrics?pretty=true", requestJSON(), requestExpects(200))
 	data, err := c.httpGet("/metrics/metrics?pretty=true", requestJSON(), requestExpects(200))
 	if err != nil {
 		return nil, err

--- a/pkg/rundeck/system_metrics.go
+++ b/pkg/rundeck/system_metrics.go
@@ -1,0 +1,38 @@
+package rundeck
+
+import (
+	"encoding/json"
+
+	multierror "github.com/hashicorp/go-multierror"
+	responses "github.com/lusis/go-rundeck/pkg/rundeck/responses"
+)
+
+// SystemMetrics represents the rundeck server system info output
+type SystemMetrics struct {
+	Version    string                 `json:"version"`
+	Gauges     map[string]interface{} `json:"gauges"`
+	Counters   map[string]interface{} `json:"counters"`
+	Histograms map[string]interface{} `json:"histograms"`
+	Meters     map[string]interface{} `json:"meters"`
+	Timers     map[string]interface{} `json:"timers"`
+}
+
+// type SystemMetrics []string
+
+// GetMetrics gets system information from the rundeck server
+// http://rundeck.org/docs/api/index.html#system-info
+func (c *Client) GetMetrics() (*SystemMetrics, error) {
+	if err := c.checkRequiredAPIVersion(responses.SystemInfoResponse{}); err != nil {
+		return nil, err
+	}
+	ls := SystemMetrics{}
+	// data, err := c.metricsHttpGet("/metrics/metrics?pretty=true", requestJSON(), requestExpects(200))
+	data, err := c.httpGet("/metrics/metrics?pretty=true", requestJSON(), requestExpects(200))
+	if err != nil {
+		return nil, err
+	}
+	if jsonErr := json.Unmarshal(data, &ls); jsonErr != nil {
+		return nil, &UnmarshalError{msg: multierror.Append(errDecoding, jsonErr).Error()}
+	}
+	return &ls, nil
+}


### PR DESCRIPTION
Support retrieve metrics from endpoint /metrics/metrics using basic auth.